### PR TITLE
폼 생성하기 페이지 드래그 및 옵션 부분 제외 완성

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -3,6 +3,7 @@ import { BrowserRouter, Routes, Route } from "react-router-dom";
 import { MainPage, NotFoundPage, ResultPage } from "@/pages";
 import GlobalStyle from "@/styles/GlobalStyle";
 import styled from "styled-components";
+import CreateFormPage from "./pages/CreateFormPage/CreateFormPage";
 
 const Layout = styled.div`
   margin: 0 auto;
@@ -17,6 +18,7 @@ function App() {
         <Routes>
           <Route path="/" element={<MainPage />}></Route>
           <Route path="/result/:id" element={<ResultPage />}></Route>
+          <Route path="/create" element={<CreateFormPage />} />
           <Route path="/*" element={<NotFoundPage />}></Route>
         </Routes>
       </BrowserRouter>

--- a/src/components/form/Editor.js
+++ b/src/components/form/Editor.js
@@ -3,15 +3,15 @@ import { MdOutlineFormatListBulleted } from "react-icons/md";
 import { GoListOrdered } from "react-icons/go";
 import styled from "styled-components";
 
+const Button = styled.button`
+  background-color: transparent;
+  border: none;
+`;
+
 const Editor = ({ editor }) => {
   if (!editor) {
     return null;
   }
-
-  const Button = styled.button`
-    background-color: transparent;
-    border: none;
-  `;
 
   return (
     <>

--- a/src/components/form/EditorSet.js
+++ b/src/components/form/EditorSet.js
@@ -1,21 +1,30 @@
+import styled from "styled-components";
 import React from "react";
 import { useEditor, EditorContent } from "@tiptap/react";
 import Editor from "./Editor";
 import StarterKit from "@tiptap/starter-kit";
 import Underline from "@tiptap/extension-underline";
 
-const EditorSet = () => {
+const EditorWrapper = styled.div`
+  * {
+    outline: none;
+  }
+`;
+
+const EditorSet = ({ value, onChange }) => {
   const editor = useEditor({
     extensions: [StarterKit, Underline],
-    content: ``,
-    onFocus: undefined,
+    content: value ?? "",
+    onUpdate({ editor }) {
+      onChange(editor.getHTML());
+    },
   });
 
   return (
-    <div>
+    <EditorWrapper>
       <Editor editor={editor} />
       <EditorContent editor={editor} />
-    </div>
+    </EditorWrapper>
   );
 };
 

--- a/src/components/form/FieldObject.js
+++ b/src/components/form/FieldObject.js
@@ -1,5 +1,3 @@
-import styled from "styled-components";
-import { useState } from "react";
 import EditorSet from "./EditorSet";
 import {
   Container,
@@ -13,49 +11,87 @@ import {
   Wysiwyg,
 } from "./styled";
 import { MdOutlineDragIndicator } from "react-icons/md";
+import { FormInputType } from "../../constants/form";
 
-const FieldObject = () => {
-  const [selectValue, setSelectValue] = useState("선택해주세요");
+const DropdownOptions = {
+  [FormInputType.Text]: "텍스트",
+  [FormInputType.Phone]: "전화번호",
+  [FormInputType.Address]: "주소",
+  [FormInputType.Select]: "드롭다운",
+  [FormInputType.File]: "첨부파일",
+  [FormInputType.Agreement]: "이용약관",
+};
 
-  const handleChange = (e) => {
-    setSelectValue(e.target.value);
+const FieldObject = ({ form, handleDeleteForm, onChange }) => {
+  const handleChangeForm = (field, value) => {
+    onChange(form.id, { [field]: value });
   };
 
   return (
     <Container>
       <OptionBar>
-        <Dropdown onChange={(e) => handleChange(e)}>
-          <option>{selectValue}</option>
-          <option value="S">S</option>
-          <option value="M">M</option>
-          <option value="L">L</option>
-          <option value="XL">XL</option>
+        <Dropdown
+          value={form.type}
+          onChange={(e) => handleChangeForm("type", e.target.value)}
+        >
+          <option value="" disabled>
+            옵션
+          </option>
+          {Object.entries(DropdownOptions).map(([key, value]) => (
+            <option key={key} value={key}>
+              {value}
+            </option>
+          ))}
         </Dropdown>
         <Input
           placeholder="필드명을 입력해 주세요"
+          value={form.title}
+          onChange={(e) => handleChangeForm("title", e.target.value)}
           height={"80%"}
           width={"100%"}
           border={"1px solid #ebeced"}
         />
         <RequiredCheck>
-          <input type="checkbox" />
+          <input
+            onChange={(e) => handleChangeForm("required", e.target.checked)}
+            type="checkbox"
+            checked={form.required}
+          />
           <label>필수</label>
         </RequiredCheck>
         <DragBtn>
           <MdOutlineDragIndicator />
         </DragBtn>
-        <DeleteBtn>x</DeleteBtn>
+        <DeleteBtn onClick={() => handleDeleteForm(form.id)}>x</DeleteBtn>
       </OptionBar>
-      <EditPlaceholder>
-        <Input
-          placeholder="해당 필드에 들어갈 placeholder를 입력해 주세요"
-          border={"none"}
-          width={"90%"}
-          height={"80%"}
-        />
-      </EditPlaceholder>
+      {[FormInputType.Text, FormInputType.Phone].includes(form.type) && (
+        <EditPlaceholder>
+          <Input
+            placeholder="해당 필드에 들어갈 placeholder를 입력해 주세요"
+            border={"none"}
+            width={"90%"}
+            height={"80%"}
+            value={form.placeholder}
+            onChange={(e) => handleChangeForm("placeholder", e.target.value)}
+          />
+        </EditPlaceholder>
+      )}
       <Wysiwyg>
-        <EditorSet />
+        <EditorSet
+          value={
+            form.type === FormInputType.Agreement
+              ? form.contents
+              : form.description
+          }
+          onChange={(html) =>
+            handleChangeForm(
+              form.type === FormInputType.Agreement
+                ? "contents"
+                : "description",
+              html,
+            )
+          }
+        />
       </Wysiwyg>
     </Container>
   );

--- a/src/components/form/FieldObject.js
+++ b/src/components/form/FieldObject.js
@@ -45,8 +45,8 @@ const FieldObject = ({ form, handleDeleteForm, onChange }) => {
         </Dropdown>
         <Input
           placeholder="필드명을 입력해 주세요"
-          value={form.title}
-          onChange={(e) => handleChangeForm("title", e.target.value)}
+          value={form.label}
+          onChange={(e) => handleChangeForm("label", e.target.value)}
           height={"80%"}
           width={"100%"}
           border={"1px solid #ebeced"}
@@ -71,7 +71,7 @@ const FieldObject = ({ form, handleDeleteForm, onChange }) => {
             border={"none"}
             width={"90%"}
             height={"80%"}
-            value={form.placeholder}
+            value={form.placeholder ?? ""}
             onChange={(e) => handleChangeForm("placeholder", e.target.value)}
           />
         </EditPlaceholder>

--- a/src/components/form/styled.js
+++ b/src/components/form/styled.js
@@ -3,7 +3,6 @@ import styled from "styled-components";
 export const Container = styled.div`
   display: flex;
   flex-direction: column;
-  max-width: 500px;
 `;
 
 export const OptionBar = styled.div`

--- a/src/constants/form.js
+++ b/src/constants/form.js
@@ -1,0 +1,8 @@
+export const FormInputType = {
+  Text: "text",
+  Address: "address",
+  Phone: "phone",
+  Select: "select",
+  Agreement: "agreement",
+  File: "file",
+};

--- a/src/pages/CreateFormPage/CreateFormPage.js
+++ b/src/pages/CreateFormPage/CreateFormPage.js
@@ -1,5 +1,6 @@
 import FieldObject from "@/components/form/FieldObject";
 import React, { useState } from "react";
+import axios from "axios";
 import {
   Layout,
   RightLayout,
@@ -10,10 +11,13 @@ import {
   SaveButton,
   FieldAddButton,
 } from "./styles";
+import { useNavigate } from "react-router-dom";
 
 const CreateFormPage = () => {
   const [title, setTitle] = useState("");
   const [formList, setFormList] = useState([]);
+
+  const nagigate = useNavigate();
 
   const onCreateForm = () => {
     setFormList((prev) => [
@@ -44,6 +48,20 @@ const CreateFormPage = () => {
     setFormList(target);
   };
 
+  const submitForm = async () => {
+    await axios.post("https://damp-dawn-99272.herokuapp.com/api/forms", {
+      form: { title: title, data: formList },
+    });
+
+    alert("성공했습니다!");
+    nagigate("/");
+  };
+
+  const isFormVaild =
+    formList.every((form) => form.type && form.label) &&
+    title.length &&
+    formList.length;
+
   return (
     <Layout>
       <KategorieText>제목 *</KategorieText>
@@ -64,7 +82,9 @@ const CreateFormPage = () => {
       <FieldAddButton onClick={onCreateForm}>필드 추가하기</FieldAddButton>
       <RightLayout>
         <CommonButton>폼열기</CommonButton>
-        <SaveButton>저장하기</SaveButton>
+        <SaveButton onClick={submitForm} disabled={!isFormVaild}>
+          저장하기
+        </SaveButton>
       </RightLayout>
     </Layout>
   );

--- a/src/pages/CreateFormPage/CreateFormPage.js
+++ b/src/pages/CreateFormPage/CreateFormPage.js
@@ -1,71 +1,67 @@
-import React from "react";
-import styled from "styled-components";
-
-const Layout = styled.div`
-  display: flex;
-  flex-direction: column;
-  padding: 10px;
-`;
-
-const RightLayout = styled.div`
-  display: flex;
-  margin-top: 10px;
-  justify-content: right;
-`;
-
-const ContentsDiv = styled.div`
-  display: flex;
-  flex-direction: column;
-  border: 1px solid black;
-  margin-top: 5px;
-`;
-
-const KategorieText = styled.span`
-  margin-top: 12px;
-  font-size: 15px;
-  color: gray;
-`;
-
-const CommonButton = styled.button`
-  cursor: pointer;
-  border: 1px solid rgb(216, 214, 214);
-  border-radius: 5px;
-  padding: 8px;
-  margin-top: 5px;
-  font-size:15px;
-`;
-
-const CommonInput = styled.input`
-  border: 1px solid rgb(216, 214, 214);
-  border-radius: 5px;
-  padding: 12px;
-  outline: none;
-  font-size: 15px;
-  margin-top: 10px;
-`;
-
-const SaveButton = styled(CommonButton)`
-  background-color: rgb(20, 80, 255);
-  color: white;
-  font-weight: 800;
-  margin-left: 10px;
-`;
-
-const FieldAddButton = styled(CommonButton)`
-  border: 1px solid rgb(20, 80, 255);
-  background-color: white;
-  color: rgb(20, 80, 255);
-  font-weight: 800;
-`;
+import FieldObject from "@/components/form/FieldObject";
+import React, { useState } from "react";
+import {
+  Layout,
+  RightLayout,
+  ContentsDiv,
+  KategorieText,
+  CommonButton,
+  CommonInput,
+  SaveButton,
+  FieldAddButton,
+} from "./styles";
 
 const CreateFormPage = () => {
+  const [title, setTitle] = useState("");
+  const [formList, setFormList] = useState([]);
+
+  const onCreateForm = () => {
+    setFormList((prev) => [
+      ...prev,
+      {
+        id: Date.now(),
+        type: "",
+        label: "",
+        description: "",
+        required: false,
+      },
+    ]);
+  };
+
+  const handleChangeForm = (id, value) => {
+    setFormList((prev) => {
+      return prev.map((item) => {
+        if (item.id === id) {
+          return { ...item, ...value };
+        }
+        return item;
+      });
+    });
+  };
+
+  const onDeleteForm = (data) => {
+    const target = formList.filter(({ id }) => id !== data);
+    setFormList(target);
+  };
+
   return (
     <Layout>
       <KategorieText>제목 *</KategorieText>
-      <CommonInput />
+      <CommonInput value={title} onChange={(e) => setTitle(e.target.value)} />
       <KategorieText>필드목록 *</KategorieText>
-      <ContentsDiv>필드 목록들 담는 div 투명으로 할 예정</ContentsDiv>
-      <FieldAddButton>필드 추가하기</FieldAddButton>
+      <ContentsDiv>
+        {formList.map((form) => {
+          return (
+            <FieldObject
+              key={form.id}
+              form={form}
+              handleDeleteForm={onDeleteForm}
+              onChange={handleChangeForm}
+            />
+          );
+        })}
+      </ContentsDiv>
+      <FieldAddButton onClick={onCreateForm}>필드 추가하기</FieldAddButton>
       <RightLayout>
         <CommonButton>폼열기</CommonButton>
         <SaveButton>저장하기</SaveButton>

--- a/src/pages/CreateFormPage/styles.js
+++ b/src/pages/CreateFormPage/styles.js
@@ -1,0 +1,57 @@
+import styled from "styled-components";
+
+export const Layout = styled.div`
+  display: flex;
+  flex-direction: column;
+  padding: 10px;
+  width: 100%;
+`;
+
+export const RightLayout = styled.div`
+  display: flex;
+  margin-top: 10px;
+  justify-content: right;
+`;
+
+export const ContentsDiv = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+
+export const KategorieText = styled.span`
+  margin-top: 12px;
+  font-size: 15px;
+  color: gray;
+`;
+
+export const CommonButton = styled.button`
+  cursor: pointer;
+  border: 1px solid rgb(216, 214, 214);
+  border-radius: 5px;
+  padding: 8px;
+  margin-top: 5px;
+  font-size: 15px;
+`;
+
+export const CommonInput = styled.input`
+  border: 1px solid rgb(216, 214, 214);
+  border-radius: 5px;
+  padding: 12px;
+  outline: none;
+  font-size: 15px;
+  margin-top: 10px;
+`;
+
+export const SaveButton = styled(CommonButton)`
+  background-color: rgb(20, 80, 255);
+  color: white;
+  font-weight: 800;
+  margin-left: 10px;
+`;
+
+export const FieldAddButton = styled(CommonButton)`
+  border: 1px solid rgb(20, 80, 255);
+  background-color: white;
+  color: rgb(20, 80, 255);
+  font-weight: 800;
+`;

--- a/src/pages/CreateFormPage/styles.js
+++ b/src/pages/CreateFormPage/styles.js
@@ -47,6 +47,9 @@ export const SaveButton = styled(CommonButton)`
   color: white;
   font-weight: 800;
   margin-left: 10px;
+  &:disabled {
+    background-color: gray;
+  }
 `;
 
 export const FieldAddButton = styled(CommonButton)`

--- a/src/pages/MainPage/MainPage.js
+++ b/src/pages/MainPage/MainPage.js
@@ -1,7 +1,8 @@
-import React, { useEffect, useState } from 'react';
-import FormList from '@/components/FormList/FormList';
-import styled from 'styled-components';
-import axios from 'axios';
+import React, { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+import FormList from "@/components/FormList/FormList";
+import styled from "styled-components";
+import axios from "axios";
 
 const Container = styled.div`
   display: flex;
@@ -52,7 +53,7 @@ const Main = () => {
   const getFormList = async () => {
     try {
       const res = await axios.get(
-        'https://damp-dawn-99272.herokuapp.com/api/forms',
+        "https://damp-dawn-99272.herokuapp.com/api/forms",
       );
       if (res.data) {
         setIsLoading(false);
@@ -68,11 +69,13 @@ const Main = () => {
     <Container>
       <Title>생성된 폼 목록</Title>
       <BoxWrapper>
-        {forms.map(form => (
+        {forms.map((form) => (
           <FormList form={form} key={form.id} />
         ))}
       </BoxWrapper>
-      <Button>폼 생성하기</Button>
+      <Link to="/create">
+        <Button>폼 생성하기</Button>
+      </Link>
     </Container>
   );
 };


### PR DESCRIPTION
##  약식 인증 로직 구현
![image](https://user-images.githubusercontent.com/38825685/155573249-d72ea32d-01f4-4e91-bedb-abf5b6cc61df.png)

처음에는 저장하기 버튼이 비활성화 되었다가.

![image](https://user-images.githubusercontent.com/38825685/155573366-1864d3b8-2156-48aa-a7d4-44b6b1f9a89b.png)

일부 필수 항목이라도 입력 했으면 활성화 됩니다. 서버에서 검증하는 로직을 구현하지 않았기 때문에 약식으로 구현하였습니다.

## 기타 

- 제가 메인 페이키 코드 아주 극히 일부 수정하였습니다. 폼 생성하기 버튼을 누르면 폼생성페이지로 가는 navigate 를 추가하였습니다. 확인 부탁드려요!
 

모두 고생하셨습니다!!